### PR TITLE
New kindest image with crio v1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN echo "Installing podman ..." \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/Release.key | gpg --dearmor | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null \
-    && DEBIAN_FRONTEND=noninteractive clean-install podman=4:4.5.1-0ubuntu22.04+obs78.3
+    && DEBIAN_FRONTEND=noninteractive clean-install podman
 
 ARG TARGETARCH
 # Configure crictl binary from upstream
@@ -119,7 +119,7 @@ ARG FUSE_OVERLAYFS_PPC64LE_SHA256SUM="e9df32f9ae46d10e525e075fd1e6ba3284d179d030
 ARG FUSE_OVERLAYFS_S390X_SHA256SUM="693c70932df666b71397163a604853362e8316e734e7202fdf342b0f6096b874"
 
 #Configure crio from upstream
-ARG CRIO_VERSION="v1.20.9"
+ARG CRIO_VERSION="v1.25.2"
 ARG CRIO_TARBALL="cri-o.${TARGETARCH}.${CRIO_VERSION}.tar.gz"
 ARG CRIO_URL="https://github.com/cri-o/cri-o/releases/download/${CRIO_VERSION}/${CRIO_TARBALL}"
 # ARG CRIO_AMD64_SHA256SUM="43f6e3a7ad6ae8cf05ed0f1e493578c28abf6a798aedb8ee9643ff7c25a68ca3"
@@ -132,7 +132,7 @@ RUN echo "Installing cri-o ..." \
     # && sha256sum --ignore-missing -c /tmp/crio.sha256 \
     # && rm -f /tmp/crio.sha256 \
     && tar -C /tmp -xzvf /tmp/crio.${TARGETARCH}.tgz \
-    && (cd /tmp/cri-o && make install)\
+    && (cd /tmp/cri-o && make all) \
     && rm -rf /tmp/cri-o /tmp/crio.${TARGETARCH}.tgz
 
 RUN echo "Installing fuse-overlayfs ..." \


### PR DESCRIPTION
Updating Dockerfile for `kindest-base-crio` image to use crio v1.25.2.